### PR TITLE
Required firmware version for 874x driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,6 @@ motorNewFocus is a submodule of [motor](https://github.com/epics-modules/motor).
 motorNewFocus can also be built outside of motor by copying it's ``EXAMPLE_RELEASE.local`` file to ``RELEASE.local`` and defining the paths to ``MOTOR`` and itself.
 
 motorNewFocus contains an example IOC that is built if ``CONFIG_SITE.local`` sets ``BUILD_IOCS = YES``.  The example IOC can be built outside of driver module.
+
+The 874x controller requires firmware v2.3 for units produced prior to early 2017. For units after early 2017, the driver works with firmware v4.06. The v2.2 is missing commands (SR/SL) used by the EPICS driver.
+In early 2017, firmware v4.06 was released. This was due to a revision in MCU/processors in which the whole MCU/processor changed. Controllers with the newer processing unit cannot be upgraded from 2.x to 4.x. However, older units with  v2.2 should be able to be upgraded to v2.3. 


### PR DESCRIPTION
The NewFocus 874x driver works only with specific versions of the firmware. The information about firmware was added to the README.md file.