### PR TITLE
Added a writeOnlyDelay argument to nf874xCreateController

### DIFF
--- a/iocs/newFocusIOC/iocBoot/iocNewFocus/newfocus8742.cmd
+++ b/iocs/newFocusIOC/iocBoot/iocNewFocus/newfocus8742.cmd
@@ -18,7 +18,7 @@ asynSetTraceIOMask("$(PORT)_ETH",-1,0x1)
 #     (4) Moving poll period (ms)
 #     (5) Idle poll period (ms)
 #     (6) Write-only delay (ms)
-nf874xCreateController("$(PORT)", "$(PORT)_ETH", 3, 200, 1000, 100)
+nf874xCreateController("$(PORT)", "$(PORT)_ETH", 3, 200, 1000, 10)
 
 ## Load record instances
 dbLoadTemplate("newfocus8742.substitutions", "P=$(PREFIX),PORT=$(PORT)")

--- a/iocs/newFocusIOC/iocBoot/iocNewFocus/newfocus8742.cmd
+++ b/iocs/newFocusIOC/iocBoot/iocNewFocus/newfocus8742.cmd
@@ -17,7 +17,8 @@ asynSetTraceIOMask("$(PORT)_ETH",-1,0x1)
 #     (3) Number of axes
 #     (4) Moving poll period (ms)
 #     (5) Idle poll period (ms)
-nf874xCreateController("$(PORT)", "$(PORT)_ETH", 3, 200, 1000)
+#     (6) Write-only delay (ms)
+nf874xCreateController("$(PORT)", "$(PORT)_ETH", 3, 200, 1000, 100)
 
 ## Load record instances
 dbLoadTemplate("newfocus8742.substitutions", "P=$(PREFIX),PORT=$(PORT)")

--- a/iocs/newFocusIOC/newFocusApp/src/Makefile
+++ b/iocs/newFocusIOC/newFocusApp/src/Makefile
@@ -5,6 +5,11 @@ include $(TOP)/configure/CONFIG
 #  ADD MACRO DEFINITIONS AFTER THIS LINE
 #=============================
 
+# EPICS base sorts libraries, which prevents motorAcsMotion from overriding
+# motor/modules/motorAcsMotion.  The following lines fix this, in theory.
+#!PROD_DEPLIB_DIRS = $(foreach word, $(INSTALL_LIB)/ \
+#!    $(dir $($*_DEPLIBS) $(PROD_DEPLIBS)), $(abspath $(word)))
+
 # The following are used for debugging messages.
 #!USR_CXXFLAGS += -DDEBUG
 

--- a/newFocusApp/src/874xMotorDriver.cpp
+++ b/newFocusApp/src/874xMotorDriver.cpp
@@ -461,6 +461,7 @@ asynStatus nf874xAxis::poll(bool *moving)
 { 
   int done;
   asynStatus comStatus;
+  static const char *functionName = "poll";
 
   // Returned poll values will include the controller id in the response if it was
   // supplied as part of the axis name. Skip past the '>' before interpreting the result.
@@ -545,6 +546,13 @@ asynStatus nf874xAxis::poll(bool *moving)
   }
 
   skip:
+  
+  if (comStatus) {
+    asynPrint(pasynUser_, ASYN_TRACE_ERROR, 
+        "%s:%s: error, comStatus=%d\n", 
+        driverName, functionName, comStatus);
+  }
+  
   setIntegerParam(pC_->motorStatusProblem_, comStatus ? 1 : 0);
   callParamCallbacks();
   return comStatus ? asynError : asynSuccess;

--- a/newFocusApp/src/874xMotorDriver.cpp
+++ b/newFocusApp/src/874xMotorDriver.cpp
@@ -39,7 +39,7 @@ static const char *driverName = "nf874xMotorDriver";
   * \param[in] idlePollPeriod    The time between polls when no axis is moving 
   */
 nf874xController::nf874xController(const char *portName, const char *nf874xPortName, int numAxes, 
-                             double movingPollPeriod, double idlePollPeriod)
+                             double movingPollPeriod, double idlePollPeriod, double writeOnlyDelay)
   //:  asynMotorController(portName, numAxes, NUM_nf874x_PARAMS, 
   :  asynMotorController(portName, numAxes+1, NUM_nf874x_PARAMS,
                          asynUInt32DigitalMask, 
@@ -51,7 +51,12 @@ nf874xController::nf874xController(const char *portName, const char *nf874xPortN
   int axis;
   asynStatus status;
   static const char *functionName = "nf874xController";
-
+  
+  writeOnlyDelay_ = writeOnlyDelay;
+  asynPrint(this->pasynUserSelf, ASYN_TRACE_ERROR, 
+      "%s:%s: nf874x write-only delay (ms): %lf\n",
+      driverName, functionName, writeOnlyDelay_);
+  
   /* Connect to nf874x controller */
   status = pasynOctetSyncIO->connect(nf874xPortName, 0, &pasynUserController_, NULL);
   if (status) {
@@ -97,11 +102,12 @@ nf874xController::nf874xController(const char *portName, const char *nf874xPortN
   * \param[in] numAxes           The number of axes that this controller supports.
   * \param[in] movingPollPeriod  The time in ms between polls when any axis is moving
   * \param[in] idlePollPeriod    The time in ms between polls when no axis is moving 
+  * \param[in] writeOnlyDelay    The time in ms to sleep before sending a write-only command 
   */
 extern "C" int nf874xCreateController(const char *portName, const char *nf874xPortName, int numAxes, 
-                                   int movingPollPeriod, int idlePollPeriod)
+                                   int movingPollPeriod, int idlePollPeriod, int writeOnlyDelay)
 {
-  new nf874xController(portName, nf874xPortName, numAxes, movingPollPeriod/1000., idlePollPeriod/1000.);
+  new nf874xController(portName, nf874xPortName, numAxes, movingPollPeriod/1000., idlePollPeriod/1000., writeOnlyDelay/1000.);
   return(asynSuccess);
 }
 
@@ -137,6 +143,12 @@ nf874xAxis* nf874xController::getAxis(int axisNo)
   return static_cast<nf874xAxis*>(asynMotorController::getAxis(axisNo));
 }
 
+/** Writes a string to the controller after a delay */ 
+asynStatus nf874xController::writeController()
+{
+  epicsThreadSleep(writeOnlyDelay_);
+  return asynMotorController::writeController();
+}
 
 /** Called when asyn clients call pasynInt32->write().
   * Extracts the function and axis number from pasynUser.
@@ -606,15 +618,17 @@ static const iocshArg nf874xCreateControllerArg1 = {"nf874x port name", iocshArg
 static const iocshArg nf874xCreateControllerArg2 = {"Number of axes", iocshArgInt};
 static const iocshArg nf874xCreateControllerArg3 = {"Moving poll period (ms)", iocshArgInt};
 static const iocshArg nf874xCreateControllerArg4 = {"Idle poll period (ms)", iocshArgInt};
+static const iocshArg nf874xCreateControllerArg5 = {"Write-only delay (ms)", iocshArgInt};
 static const iocshArg * const nf874xCreateControllerArgs[] = {&nf874xCreateControllerArg0,
                                                            &nf874xCreateControllerArg1,
                                                            &nf874xCreateControllerArg2,
                                                            &nf874xCreateControllerArg3,
-                                                           &nf874xCreateControllerArg4};
-static const iocshFuncDef nf874xCreateControllerDef = {"nf874xCreateController", 5, nf874xCreateControllerArgs};
+                                                           &nf874xCreateControllerArg4,
+                                                           &nf874xCreateControllerArg5};
+static const iocshFuncDef nf874xCreateControllerDef = {"nf874xCreateController", 6, nf874xCreateControllerArgs};
 static void nf874xCreateControllerCallFunc(const iocshArgBuf *args)
 {
-  nf874xCreateController(args[0].sval, args[1].sval, args[2].ival, args[3].ival, args[4].ival);
+  nf874xCreateController(args[0].sval, args[1].sval, args[2].ival, args[3].ival, args[4].ival, args[5].ival);
 }
 
 static void nf874xMotorRegister(void)

--- a/newFocusApp/src/874xMotorDriver.h
+++ b/newFocusApp/src/874xMotorDriver.h
@@ -61,11 +61,12 @@ friend class nf874xController;
 
 class epicsShareClass nf874xController : public asynMotorController {
 public:
-  nf874xController(const char *portName, const char *nf874xPortName, int numAxes, double movingPollPeriod, double idlePollPeriod);
+  nf874xController(const char *portName, const char *nf874xPortName, int numAxes, double movingPollPeriod, double idlePollPeriod, double writeOnlyDelay);
 
   /* These are the methods that we override from asynMotorDriver */
   asynStatus writeInt32(asynUser *pasynUser, epicsInt32 value);
   asynStatus writeFloat64(asynUser *pasynUser, epicsFloat64 value);
+  asynStatus writeController();
   void report(FILE *fp, int level);
   nf874xAxis* getAxis(asynUser *pasynUser);
   nf874xAxis* getAxis(int axisNo);
@@ -77,6 +78,8 @@ protected:
   int motorUpdateInterval_;
   int motorDeadband_;
   int motorFollowingError_;
+  
+  double writeOnlyDelay_;
 
   int hasClosedLoopSupport_;  /**< Flag indicating if controller supports closed-loop functionality */
 


### PR DESCRIPTION
Added a writeOnlyDelay argument to nf874xCreateController, which works around the problem of delayed replies from the controller when autosave restores values.